### PR TITLE
DSOPS-81 Use CodeBuild Project Version 1.7 to Expose Environment Variable DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+#### PR description
+
+What is it for?
+
+#### Testing instructions
+
+-
+-
+
+#### JIRA ticket information
+
+Story: [DSOPS-000](https://jira.theglobeandmail.com/browse/DSOPS-000)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ module "ecr_pipeline" {
 The account that owns the guthub token must have admin access on the repo in order to generate a github webhook 
 
 ## v1.4 Note
-If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebild
+If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebuild
 
 You can add these 2 lines to the beginning of your `build` phase commands in `buildspec.yml` to login to Dockerhub
 
@@ -36,16 +36,19 @@ You can add these 2 lines to the beginning of your `build` phase commands in `bu
 ```
 
 ## v1.7 Note
-The environment variable `DS_DEPLOY_GITHUB_TOKEN` is exposed via codebild
+The secrets manager environment variable `DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID` is exposed via codebuild
 
-You can add these 2 lines to the beginning of your `env` sequence in `buildspec.yml` to use this variable in your `build` phase commands.
+You can add the first line to the beginning of your `build` phase commands in `buildspec.yml` to assign the token's secret value to local variable `GITHUB_TOKEN`.
 
-```yml
-env:
-  secrets-manager:
-    DS_DEPLOY_GITHUB_TOKEN: $DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID
-    ...
-    ...
+```yml d
+  build:
+    commands:
+      - export GITHUB_TOKEN=${DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID}
+      ...
+      ...
+      - docker build -t $REPOSITORY_URI:latest --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} .
+      ...
+      ...
 ```
 ## Inputs
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ You can add these 2 lines to the beginning of your `build` phase commands in `bu
       ...
 ```
 
+## v1.7 Note
+The environment variable `DS_DEPLOY_GITHUB_TOKEN` is exposed via codebild
+
+You can add these 2 lines to the beginning of your `env` sequence in `buildspec.yml` to use this variable in your `build` phase commands.
+
+```yml
+env:
+  secrets-manager:
+    DS_DEPLOY_GITHUB_TOKEN: $DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID
+    ...
+    ...
+```
 ## Inputs
 
 | Name | Description | Type | Default | Required |

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "codepipeline_baseline" {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.6"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=1.7"
 
   name                   = var.name
   deploy_type            = "ecr"


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to upgrade the codebuild project module version to 1.7 to expose the secrets-manager environment variable DS_DEPLOY_GITHUB_TOKEN_SECRETS_ID.
Also added release note to README.md.

#### Testing instructions

- Test the new version of the code pipeline module in any Sophi pop code pipeline.
- Verify a successful release in the test code pipeline.

#### JIRA ticket information

Story: [DSOPS-81](https://jira.theglobeandmail.com/browse/DSOPS-81)