### PR TITLE
v2.1 Upgrade codebuild_project Module Version to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Creates a pipeline that builds a container via codebuild and pushes it to an ECR
 
 ```hcl
 module "ecr_pipeline" {
-  source = "github.com/globeandmail/aws-codepipeline-ecr?ref=1.9"
+  source = "github.com/globeandmail/aws-codepipeline-ecr?ref=2.1"
 
   name               = app-name
   ecr_name           = repo-name
@@ -16,9 +16,11 @@ module "ecr_pipeline" {
     Environment = var.environment
   }
   use_repo_access_github_token = true
-  svcs_account_github_token_aws_secret_arn = svcs-account-github-token-aws-secret-arn
-  svcs_account_github_token_aws_kms_cmk_arn = svcs-account-github-token-aws-kms-cmk-arn
-  s3_block_public_access = true
+  svcs_account_github_token_aws_secret_arn     = svcs-account-github-token-aws-secret-arn
+  svcs_account_aws_kms_cmk_arn                 = svcs-account-aws-kms-cmk-arn
+  s3_block_public_access                       = true
+  use_sysdig_api_token                         = true
+  svcs_account_sysdig_api_token_aws_secret_arn = svcs-account-sysdig-api-token-aws-secret-arn
 }
 ```
 
@@ -26,7 +28,7 @@ module "ecr_pipeline" {
 The account that owns the guthub token must have admin access on the repo in order to generate a github webhook 
 
 ## v1.4 Note
-If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebuild
+If `use_docker_credentials` is set to `true`, the environment variables `DOCKERHUB_USER` and `DOCKERHUB_PASS` are exposed via codebuild.
 
 You can add these 2 lines to the beginning of your `build` phase commands in `buildspec.yml` to login to Dockerhub
 
@@ -60,6 +62,24 @@ If `use_repo_access_github_token` is set to `true`, the environment variable `RE
 Usage remains the same as v1.7.
 If `s3_block_public_access` is set to `true`, the block public access setting for the artifact bucket is enabled.
 
+## v.2.1 Note
+If `use_sysdig_api_token` is set to `true`, the secrets manager environment variable `SYSDIG_API_TOKEN_SECRETS_ID` is exposed via codebuild.
+
+You can add these 8 lines to the end of your `build` phase commands in `buildspec.yml` to run Sysdig image security scans.
+```yml
+  build:
+    commands:
+      ...
+      ...
+      - echo "Running Sysdig image inline scan..."
+      - docker run --rm -u $(id -u) -v /var/run/docker.sock:/var/run/docker.sock -v $(pwd)/reports:/staging/reports quay.io/sysdig/secure-inline-scan:2 -s https://us2.app.sysdig.com -k ${SYSDIG_API_TOKEN_SECRETS_ID} --storage-type docker-daemon --storage-path /var/run/docker.sock -r /staging/reports ${REPOSITORY_URI}:${IMAGE_TAG} || true
+      - echo "Downloading Sysdig Cli Scanner..."
+      - curl -LO "https://download.sysdig.com/scanning/bin/sysdig-cli-scanner/$(curl -L -s https://download.sysdig.com/scanning/sysdig-cli-scanner/latest_version.txt)/linux/amd64/sysdig-cli-scanner"
+      - echo "Adding executable permission to sysdig-cli-scanner binary..."
+      - chmod +x ./sysdig-cli-scanner
+      - echo "Running Sysdig image cli scan..."
+      - SECURE_API_TOKEN=${SYSDIG_API_TOKEN_SECRETS_ID} ./sysdig-cli-scanner --apiurl https://us2.app.sysdig.com ${REPOSITORY_URI}:${IMAGE_TAG} --policy sysdig_best_practices || true
+```
 
 ## Inputs
 
@@ -76,9 +96,11 @@ If `s3_block_public_access` is set to `true`, the block public access setting fo
 | tags | A mapping of tags to assign to the resource | map | `{}` | no |
 | use\_repo\_access\_github\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the REPO\_ACCESS\_GITHUB\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
 | svcs\_account\_github\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the repo access Github token.<br>The secret is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
-| svcs\_account\_github\_token\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token is true. | `string` | `null` | no |
+| svcs\_account\_aws\_kms\_cmk\_arn | \(Optional\)  The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.<br>The key is created in the shared service account.<br>Required if var.use\_repo\_access\_github\_token or var.use\_sysdig\_api\_token is true. | `string` | `null` | no | yes |
 | create\_github\_webhook | Create the github webhook that triggers codepipeline | bool | `"true"` | no |
 | s3\_block\_public\_access | \(Optional\) Enable the S3 block public access setting for the artifact bucket. | `bool` | `false` | no |
+| use\_sysdig\_api\_token | \(Optional\) Allow the AWS codebuild IAM role read access to the SYSDIG\_API\_TOKEN secrets manager secret in the shared service account.<br>Defaults to false. | `bool` | `false` | no |
+| svcs\_account\_sysdig\_api\_token\_aws\_secret\_arn | \(Optional\) The AWS secret ARN for the sysdig API token.<br>The secret is created in the shared service account.<br>Required if var.use\_sysdig\_api\_token is true. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "codepipeline_baseline" {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=2.0"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=2.1"
 
   name                                         = var.name
   deploy_type                                  = "ecr"

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "aws_iam_role_policy" "codepipeline_baseline" {
 }
 
 module "codebuild_project" {
-  source = "github.com/globeandmail/aws-codebuild-project?ref=1.8"
+  source = "github.com/globeandmail/aws-codebuild-project?ref=2.0"
 
   name                                         = var.name
   deploy_type                                  = "ecr"
@@ -67,8 +67,10 @@ module "codebuild_project" {
   tags                                         = var.tags
   use_repo_access_github_token                 = var.use_repo_access_github_token
   svcs_account_github_token_aws_secret_arn     = var.svcs_account_github_token_aws_secret_arn
-  svcs_account_github_token_aws_kms_cmk_arn    = var.svcs_account_github_token_aws_kms_cmk_arn
+  svcs_account_aws_kms_cmk_arn                 = var.svcs_account_aws_kms_cmk_arn
   s3_block_public_access                       = var.s3_block_public_access
+  use_sysdig_api_token                         = var.use_sysdig_api_token
+  svcs_account_sysdig_api_token_aws_secret_arn = var.svcs_account_sysdig_api_token_aws_secret_arn
 }
 
 resource "aws_codepipeline" "pipeline" {

--- a/variables.tf
+++ b/variables.tf
@@ -72,12 +72,12 @@ variable "svcs_account_github_token_aws_secret_arn" {
   default     = null
 }
 
-variable "svcs_account_github_token_aws_kms_cmk_arn" {
+variable "svcs_account_aws_kms_cmk_arn" {
   type        = string
   description = <<EOT
-                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting the repo access Github token AWS secret.
+                (Optional) The us-east-1 region AWS KMS customer managed key ARN for encrypting all AWS secrets.
                 The key is created in the shared service account.
-                Required if var.use_repo_access_github_token is true.
+                Required if var.use_repo_access_github_token or var.use_sysdig_api_token is true.
                 EOT
   default     = null
 }
@@ -92,4 +92,23 @@ variable "s3_block_public_access" {
   type = bool
   description = "(Optional) Enable the S3 block public access setting for the artifact bucket."
   default = false
+}
+
+variable "use_sysdig_api_token" {
+  type        = bool
+  description = <<EOT
+                (Optional) Allow the AWS codebuild IAM role read access to the SYSDIG_API_TOKEN secrets manager secret in the shared service account.
+                Defaults to false.
+                EOT
+  default     = false
+}
+
+variable "svcs_account_sysdig_api_token_aws_secret_arn" {
+  type        = string
+  description = <<EOT
+                (Optional) The AWS secret ARN for the sysdig API token.
+                The secret is created in the shared service account.
+                Required if var.use_sysdig_api_token is true.
+                EOT
+  default     = null
 }


### PR DESCRIPTION
#### PR description

What is it for?
The PR is to add the optional variables `use_sysdig_api_token` and `svcs_account_sysdig_api_token_aws_secret_arn`.
The AWS secret is in the ds-ml-shared-svcs-prod AWS account.
The API token is for Sysdig image scanning.
Also renamed optional variable `svcs_account_aws_kms_cmk_arn`.
Upgraded `codebuild_project` module version to tag version 2.0.
 
#### Testing instructions

- Verify that the new module version 2.1 is deployable in the mutli-tenant AWS accounts.

#### JIRA ticket information

Story: [AHP-1113](https://jira.theglobeandmail.com/browse/AHP-1113)